### PR TITLE
Container: handle null c.type and early exit to avoid overwrite

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -6,10 +6,11 @@ function hasChildrenWithVerticalFill(children) {
 	var result = false;
 
 	React.Children.forEach(children, (c) => {
-		if (c.type && c.type.shouldFillVerticalSpace) {
-			result = true;
-			return;
-		}
+		if (result) return; // early-exit
+		if (!c) return;
+		if (!c.type) return
+		
+		result = !!c.type.shouldFillVerticalSpace;
 	});
 
 	return result;


### PR DESCRIPTION
ping @JedWatson,  still getting my head around this, but this seems like the original intention.
